### PR TITLE
Add basic multi-page website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # hello-web
-my first test repo
+
+My first test repo showcasing a simple website.
+
+## Running
+
+Open `public/index.html` in your browser.
+
+## Testing
+
+Run `npm test` to execute a simple unit test.

--- a/myfirstfile.txt
+++ b/myfirstfile.txt
@@ -1,1 +1,1 @@
-Hello world
+Hello web

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hello-web",
+  "version": "1.0.0",
+  "description": "Simple website demonstrating multiple scripts",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/utils.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/public/about.html
+++ b/public/about.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>About</title>
+  <link rel="stylesheet" href="styles/style.css" />
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+  </nav>
+  <p id="about-greeting"></p>
+  <script type="module" src="scripts/about.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Hello Web</title>
+  <link rel="stylesheet" href="styles/style.css" />
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+  </nav>
+  <h1 id="greeting">Loading...</h1>
+  <script type="module" src="scripts/main.js"></script>
+</body>
+</html>

--- a/public/scripts/about.js
+++ b/public/scripts/about.js
@@ -1,0 +1,8 @@
+import { greet } from './utils.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const el = document.getElementById('about-greeting');
+  if (el) {
+    el.textContent = greet('from the about page');
+  }
+});

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,0 +1,8 @@
+import { greet } from './utils.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const el = document.getElementById('greeting');
+  if (el) {
+    el.textContent = greet('web');
+  }
+});

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1,0 +1,3 @@
+export function greet(target) {
+  return `Hello ${target}!`;
+}

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -1,0 +1,7 @@
+body {
+  font-family: sans-serif;
+  margin: 2rem;
+}
+nav a {
+  margin-right: 1rem;
+}

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,5 @@
+import assert from 'assert';
+import { greet } from '../public/scripts/utils.js';
+
+assert.strictEqual(greet('web'), 'Hello web!');
+console.log('utils.greet works');


### PR DESCRIPTION
## Summary
- Create index and about pages with shared navigation, modular scripts, and basic styling
- Implement greeting utility and page scripts
- Document usage and add a unit test for greeting logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e4de7158483338e1e3435bd8aef59