### PR TITLE
Add simple multi-page website with modular scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # hello-web
-my first test repo
+
+My first test repo containing a simple multi-page website.
+
+## Getting Started
+
+Open `index.html` in a browser to see the greeting. Use `about.html` for more info.
+
+## Testing
+
+Run `npm test` to execute the unit tests.

--- a/about.html
+++ b/about.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>About - Hello Web</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <h1>About</h1>
+  <p id="about-text"></p>
+  <script type="module" src="js/about.js"></script>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,8 @@
+body {
+  font-family: sans-serif;
+  margin: 2rem;
+}
+
+a {
+  color: #0366d6;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Hello Web</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <h1 id="greeting"></h1>
+  <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/js/about.js
+++ b/js/about.js
@@ -1,0 +1,3 @@
+import { greeting } from './helper.js';
+
+document.getElementById('about-text').textContent = `This site says: ${greeting()}`;

--- a/js/helper.js
+++ b/js/helper.js
@@ -1,0 +1,3 @@
+export function greeting(name = 'web') {
+  return `Hello ${name}!`;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,3 @@
+import { greeting } from './helper.js';
+
+document.getElementById('greeting').textContent = greeting();

--- a/myfirstfile.txt
+++ b/myfirstfile.txt
@@ -1,1 +1,1 @@
-Hello world
+Hello web

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "hello-web",
+  "version": "1.0.0",
+  "description": "Simple website example",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/greeting.test.js
+++ b/tests/greeting.test.js
@@ -1,0 +1,7 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { greeting } from '../js/helper.js';
+
+test('greeting returns Hello web!', () => {
+  assert.equal(greeting(), 'Hello web!');
+});


### PR DESCRIPTION
## Summary
- Add basic multi-page website with separate scripts for main and about pages
- Implement helper module and styling
- Introduce unit test using Node's built-in test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e4de7158483338e1e3435bd8aef59